### PR TITLE
feat(174): 이미지 잘리지 않도록 css 수정

### DIFF
--- a/src/components/common/Album/Album.tsx
+++ b/src/components/common/Album/Album.tsx
@@ -65,10 +65,6 @@ const albumContainerStyle = (theme: Theme) =>
       alignItems: 'center',
       backgroundColor: theme.colors.bg,
     },
-    img: {
-      width: '100%',
-      objectFit: 'cover',
-    },
   })
 
 const dotContainerStyle = css({

--- a/src/components/common/Img/Img.tsx
+++ b/src/components/common/Img/Img.tsx
@@ -59,6 +59,6 @@ export default function Img({
 
 const defaultStyle = (isLoaded: boolean) =>
   css({
-    objectFit: 'cover',
+    objectFit: 'contain',
     display: isLoaded ? 'block' : 'none',
   })


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #174 

## 📝작업 내용

포스트 이미지 css 수정

- 스타일링: Post 이미지 잘리지 않고 여백과 함께 출력되도록 css 수정했습니다.

![화면 기록 2025-12-09 오후 2 45 54](https://github.com/user-attachments/assets/db8a5f3b-3939-41da-95c9-e0a95c0e3a1c)


## 💬리뷰 요구사항(선택)

ex) 테스트 예시 코드도 작성해보겠습니다.
