### PR TITLE
fix(190): HeaderLayout에 no-scrollbar 추가

### DIFF
--- a/src/layouts/HeaderLayout.tsx
+++ b/src/layouts/HeaderLayout.tsx
@@ -10,7 +10,7 @@ export default function HeaderLayout() {
   return (
     <>
       <Header />
-      <main css={mainStyle}>
+      <main css={mainStyle} className='no-scrollbar'>
         <PageTransition keyframe={slideInRight}>
           <Outlet />
           <div css={{ height: withSafeAreaBottom(0), flexShrink: 0 }} />


### PR DESCRIPTION
## #️⃣연관된 이슈

Resolves #190 

## 📝작업 내용

HeaderLayout에서 랜더링되는 페이지들의 스크롤 바 삭제했습니다.

## 💬리뷰 요구사항(선택)

(수정 전)
![sc 중간](https://github.com/user-attachments/assets/ca647968-0b34-4e3a-ac1a-bd3da17581e0)


(수정 후)
![sc2 중간](https://github.com/user-attachments/assets/3724503a-4dc8-4ed3-b479-19843df7406c)
